### PR TITLE
Add 'Debug (local-deps)' profile

### DIFF
--- a/ImageLib.Test/ImageLib.Test.csproj
+++ b/ImageLib.Test/ImageLib.Test.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Configurations>Debug;Release;Debug (local-deps)</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ImageLib.sln
+++ b/ImageLib.sln
@@ -11,18 +11,25 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLib.Test", "ImageLib.T
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug (local-deps)|Any CPU = Debug (local-deps)|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Debug (local-deps)|Any CPU.ActiveCfg = Debug (local-deps)|Any CPU
+		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Debug (local-deps)|Any CPU.Build.0 = Debug (local-deps)|Any CPU
 		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD199C16-7D03-4F3F-8A6C-61F04998D19F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Debug (local-deps)|Any CPU.ActiveCfg = Debug (local-deps)|Any CPU
+		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Debug (local-deps)|Any CPU.Build.0 = Debug (local-deps)|Any CPU
 		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EB10C45-05C4-43EB-8BF4-88C8126CE8C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9F89D53-DD47-43D2-AEAE-B55A705BF2C3}.Debug (local-deps)|Any CPU.ActiveCfg = Debug (local-deps)|Any CPU
+		{E9F89D53-DD47-43D2-AEAE-B55A705BF2C3}.Debug (local-deps)|Any CPU.Build.0 = Debug (local-deps)|Any CPU
 		{E9F89D53-DD47-43D2-AEAE-B55A705BF2C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9F89D53-DD47-43D2-AEAE-B55A705BF2C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9F89D53-DD47-43D2-AEAE-B55A705BF2C3}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/ImageLib/ImageLib.csproj
+++ b/ImageLib/ImageLib.csproj
@@ -44,6 +44,5 @@
 		<ProjectReference Include="..\..\MathLib\MathLib\MathLib.csproj" />
 		<ProjectReference Include="..\..\MathLib\MathLib.Imaging\MathLib.Imaging.csproj" />
 		<ProjectReference Include="..\..\UtilLib\UtilLib\UtilLib.csproj" />
-		<ProjectReference Include="..\..\MathLib\MathLib\MathLib.csproj" />
 	</ItemGroup>
 </Project>

--- a/ImageLib/ImageLib.csproj
+++ b/ImageLib/ImageLib.csproj
@@ -1,21 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	<LangVersion>preview</LangVersion>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>0.0.9</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>preview</LangVersion>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Version>0.0.9</Version>
+		<Configurations>Debug;Release;Debug (local-deps)</Configurations>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="carlst99.ZlibNGSharp" Version="1.2.0" />
-    <PackageReference Include="MathLib" Version="0.0.20" />
-    <PackageReference Include="MathLib.Imaging" Version="0.0.20" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="UtilLib" Version="0.0.24" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="carlst99.ZlibNGSharp" Version="1.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+	</ItemGroup>
 
+	<!-- 
+	For developing locally, by cloning all repos and putting them in the same directory:
+		henke/
+			ImageLib/
+			MathLib/
+			UtilLib/
+	This setting allows you to use local projects instead of NuGet packages.  
+
+	NOTE:
+		Visual Studio will refuse to resolve include paths outside current directory.
+		As such, whenever changing TO this profile, you must run the following command
+		in PowerShell/terminal:
+			`dotnet restore -p:UseLocalProjects=true`
+		It is persistent accross clean, rebuild, relaunching Visual Studio, etc. Only
+		when changing to this profile.
+	-->
+	<PropertyGroup Condition="'$(Configuration)'=='Debug (local-deps)'">
+		<UseLocalProjects>true</UseLocalProjects>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(UseLocalProjects)' != 'true'">
+		<PackageReference Include="MathLib" Version="0.0.20" />
+		<PackageReference Include="MathLib.Imaging" Version="0.0.20" />
+		<PackageReference Include="UtilLib" Version="0.0.24" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(UseLocalProjects)' == 'true'">
+		<ProjectReference Include="..\..\MathLib\MathLib\MathLib.csproj" />
+		<ProjectReference Include="..\..\MathLib\MathLib.Imaging\MathLib.Imaging.csproj" />
+		<ProjectReference Include="..\..\UtilLib\UtilLib\UtilLib.csproj" />
+		<ProjectReference Include="..\..\MathLib\MathLib\MathLib.csproj" />
+	</ItemGroup>
 </Project>

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Configurations>Debug;Release;Debug (local-deps)</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a new solution configuration - `Debug (local-deps)` - to use local paths instead of NuGet packages.

![image](https://github.com/user-attachments/assets/761231de-f37e-4d6d-af8a-a4eecf0b48f8)
